### PR TITLE
Add a convenience subclass or error reporting mixin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-form-error-reporting',
-    version='0.1',
+    version='0.2',
     author='Ministry of Justice Digital Services',
     url='https://github.com/ministryofjustice/django-form-error-reporting',
     py_modules=['form_error_reporting'],


### PR DESCRIPTION
• which allows the tracking ID to be retrieved from Django settings,
• and retrieves the client ID from cookie if available
