### PR TITLE
Fix import error when trying to get the library version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Please report bugs and open pull requests on `GitHub`_.
 
 Use ``python setup.py test`` to run all tests.
 
-Distribute a new version by updating the ``VERSION`` tuple in ``form_error_reporting`` and run ``python setup.py sdist bdist_wheel upload``.
+Distribute a new version by updating the ``version`` argument in ``setup.py:setup`` and run ``python setup.py sdist bdist_wheel upload``.
 
 Copyright
 ---------

--- a/form_error_reporting.py
+++ b/form_error_reporting.py
@@ -9,8 +9,6 @@ from django.conf import settings
 import requests
 from six.moves.urllib.parse import quote, urljoin
 
-VERSION = (0, 5)
-__version__ = '.'.join(map(str, VERSION))
 __all__ = ('GAErrorReportingMixin', 'GARequestErrorReportingMixin')
 
 logger = logging.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import importlib
 import os
 import sys
 
@@ -11,14 +10,12 @@ if sys.version_info < (3, 3):
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-__version__ = importlib.import_module('form_error_reporting').__version__
-
 with open('README.rst') as readme:
     README = readme.read()
 
 setup(
     name='django-form-error-reporting',
-    version=__version__,
+    version='0.6',
     author='Ministry of Justice Digital Services',
     url='https://github.com/ministryofjustice/django-form-error-reporting',
     py_modules=['form_error_reporting'],


### PR DESCRIPTION
from `setup.py` before dependencies are available